### PR TITLE
fix: improve search clearing and docs

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -163,7 +163,7 @@
 | 需求                   | 推荐子代理         |
 | ---------------------- | ------------------ |
 | 了解聊天内容           | chat-summarizer    |
-| 发送消息但不知道怎么说 | message-composer   |
+| 发送消息但不知道怎么说 | auto-replier       |
 | 快速回复消息           | auto-replier       |
 | 查找历史信息           | message-searcher   |
 | 批量检查多个聊天       | multi-chat-checker |
@@ -181,12 +181,12 @@
 
   - 工具：`mcp__wechat-mcp__fetch_messages_by_chat`
 
-- **读取+发送**：message-composer, auto-replier
+- **读取+发送**：auto-replier
   - 工具：`mcp__wechat-mcp__fetch_messages_by_chat`, `mcp__wechat-mcp__reply_to_messages_by_chat`
 
 ### 模型选择
 
-- **Sonnet 模型**：chat-summarizer, message-composer, chat-insights
+- **Sonnet 模型**：chat-summarizer, auto-replier, chat-insights
 
   - 需要深度理解和复杂推理
 

--- a/docs/detailed-guide.md
+++ b/docs/detailed-guide.md
@@ -192,7 +192,7 @@ Configures dual logging:
 
 The project has a comprehensive logging setup:
 
-- Logs are written to a rotating file under the `logs/` directory (by default `logs/wechat_mcp.log`)
+- Logs are written to a file under the `logs/` directory (by default `logs/wechat_mcp.log`)
 - Logs are also sent to the terminal (stdout)
 
 You can customize the log directory via:

--- a/src/wechat_mcp/wechat_accessibility.py
+++ b/src/wechat_mcp/wechat_accessibility.py
@@ -10,6 +10,7 @@ from ApplicationServices import (
     AXUIElementCreateApplication,
     AXUIElementCopyAttributeValue,
     AXUIElementPerformAction,
+    AXUIElementSetAttributeValue,
     AXValueGetType,
     AXValueGetValue,
     kAXChildrenAttribute,
@@ -286,7 +287,9 @@ def focus_and_type_search(ax_app, text: str):
     AXUIElementPerformAction(search, kAXRaiseAction)
 
     # Clear any existing value via AX (best effort).
-    AXUIElementCopyAttributeValue(search, kAXValueAttribute, None)
+    err = AXUIElementSetAttributeValue(search, kAXValueAttribute, "")
+    if err != 0:
+        logger.debug("Failed to clear search field via AX (err=%s)", err)
 
     pb = AppKit.NSPasteboard.generalPasteboard()
     pb.clearContents()


### PR DESCRIPTION
## Summary
- `src/wechat_mcp/wechat_accessibility.py`: replaced the no‑op clear with a best‑effort `AXUIElementSetAttributeValue(..., "")` and debug logging on failure.
- `docs/detailed-guide.md`: corrected logging description to remove "rotating".
- `.claude/agents/README.md`: removed message-composer references and updated recommendations/tool permissions/model list.