### PR TITLE
feat: add quote_reply_to_message tool for quoting and replying to spe…

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 An MCP server that automates WeChat on macOS using the Accessibility API and screen capture. It enables LLMs to interact with WeChat chats programmatically.
 
 ## Features
-
 - 📨 Fetch recent messages from any chat (contact or group)
 - ✍️ Send automated replies based on chat history
+- 💬 Quote and reply to specific messages with context
 - 📷 Publish text-only Moments posts, with optional draft-only mode
 - 👥 Add contacts using WeChat ID with configurable privacy
 - 🔍 Smart chat search with exact name matching
@@ -112,6 +112,7 @@ wechat-mcp --transport sse
 
 - **`fetch_messages_by_chat`** - Get recent messages from a chat
 - **`reply_to_messages_by_chat`** - Send a reply to a chat
+- **`quote_reply_to_message`** - Quote a specific message and send a reply with the quoted context attached
 - **`add_contact_by_wechat_id`** - Add a new contact using a WeChat ID and send a friend request
 - **`publish_moment_without_media`** - Publish a text-only Moments post (no photos or videos); optionally only prepare a draft without posting via `publish=False`
 
@@ -167,3 +168,4 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 ## License
 
 MIT License - see [LICENSE](LICENSE) file for details
+

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -16,6 +16,7 @@
 
 - 📨 获取任何聊天（联系人或群组）的最近消息
 - ✍️ 基于聊天历史自动发送回复
+- 💬 引用特定消息并发送带上下文的回复
 - 📷 发布纯文字朋友圈消息，并可设置仅创建草稿
 - 👥 通过微信号添加联系人并配置隐私选项
 - 🔍 智能聊天搜索，支持精确名称匹配
@@ -112,6 +113,7 @@ wechat-mcp --transport sse
 
 - **`fetch_messages_by_chat`** - 获取聊天的最近消息
 - **`reply_to_messages_by_chat`** - 向聊天发送回复
+- **`quote_reply_to_message`** - 引用特定消息并发送带引用上下文的回复
 - **`add_contact_by_wechat_id`** - 通过微信号添加联系人并发送好友申请
 - **`publish_moment_without_media`** - 发布纯文字朋友圈（无图片或视频），也可以通过 `publish=False` 仅填充草稿而不真正发布
 
@@ -167,3 +169,4 @@ uv run wechat-mcp --transport stdio
 ## 许可证
 
 MIT License - 详见 [LICENSE](../LICENSE) 文件
+

--- a/docs/detailed-guide.md
+++ b/docs/detailed-guide.md
@@ -44,6 +44,31 @@ If an error occurs, the tools return an object containing an `"error"` field des
 
 Internally, `fetch_messages_by_chat` scrolls the WeChat message list using the system's standard macOS scroll semantics (no third‑party scroll reversal tools enabled) and continues scrolling until it has assembled the true last `last_n` messages or reached the beginning of the chat history, rather than stopping after a fixed number of scroll steps.
 
+### `quote_reply_to_message`
+
+**Signature**: `quote_reply_to_message(chat_name: str, target_text: str, reply_message: str) -> dict`
+
+Quotes a specific message in the given chat and sends a reply with the quoted context attached. This tool:
+
+- Opens the specified chat (or stays in the current one if it already matches).
+- Finds the message whose text contains `target_text` in the visible message list.
+- Right-clicks on that message to open the context menu.
+- Clicks the "Quote" menu item to attach the quoted message to the input field.
+- Types the `reply_message` and sends it.
+
+The `target_text` should be a unique substring of the message you want to quote. Returns:
+
+```json
+{
+  "chat_name": "The chat (contact or group)",
+  "quoted_text": "The text that was quoted",
+  "reply_text": "The reply that was sent",
+  "sent": true
+}
+```
+
+If the target message is not found in the visible messages, or the context menu "Quote" item cannot be located, the tool returns an `"error"` description.
+
 ### `add_contact_by_wechat_id`
 
 **Signature**:\
@@ -80,6 +105,7 @@ The main MCP server implementation that:
 - Defines the tool functions decorated with `@mcp.tool()`
   - `fetch_messages_by_chat(...)`
   - `reply_to_messages_by_chat(...)`
+  - `quote_reply_to_message(...)`
   - `add_contact_by_wechat_id(...)`
 - Handles multiple transport types (stdio, streamable-http, sse)
 - Provides the main entry point via the `main()` function
@@ -179,6 +205,16 @@ Contains the helpers used by `reply_to_messages_by_chat` for sending messages:
 - `send_message(text)` - Send a message via Accessibility API
 - `find_input_field(ax_app)` - Locate chat input field
 - `press_return()` - Synthesize Return key press
+
+#### `src/wechat_mcp/quote_reply_utils.py`
+
+Contains the helpers used by `quote_reply_to_message` for quoting and replying:
+
+- `quote_and_reply(target_text, reply_text)` - Main function: find message, right-click, quote, and send reply
+- `right_click_element_center(element)` - Synthesize a right mouse click at element center
+- `find_context_menu_item(ax_app, item_title, timeout)` - Wait for and find a context menu item by title
+- `find_message_element(msg_list, target_text)` - Find a message element containing the target text
+- `dismiss_context_menu(ax_app)` - Press Escape to dismiss any open context menu
 
 #### `src/wechat_mcp/logging_config.py`
 
@@ -295,3 +331,4 @@ The search implementation prefers exact matches. If a contact name is not found:
 - [ ] Fetch moments by chat name
 - [ ] Support WeChat with Chinese language
 - [ ] Identify OTHER with explicit name
+

--- a/src/wechat_mcp/mcp_server.py
+++ b/src/wechat_mcp/mcp_server.py
@@ -13,6 +13,7 @@ from .add_contact_by_wechat_id_utils import (
 from .fetch_messages_by_chat_utils import ChatMessage, fetch_recent_messages
 from .publish_moment_utils import publish_moment_without_media as ax_publish_moment
 from .reply_to_messages_by_chat_utils import send_message
+from .quote_reply_utils import quote_and_reply
 from .wechat_accessibility import get_current_chat_name, open_chat_for_contact
 
 
@@ -238,6 +239,61 @@ def publish_moment_without_media(
         }
 
 
+@mcp.tool()
+def quote_reply_to_message(
+    chat_name: str,
+    target_text: str,
+    reply_message: str,
+) -> dict[str, Any]:
+    """
+    Quote a specific message and send a reply in the given chat.
+
+    This will:
+    - Open the specified chat (contact or group).
+    - Find the message whose text contains ``target_text``.
+    - Right-click on that message and select "Quote" from the context
+      menu.
+    - Type the reply text and send it with the quoted message attached.
+
+    The ``target_text`` should be a unique substring of the message you
+    want to quote. If the chat is already open, it will not re-navigate.
+    """
+    logger.info(
+        "Tool quote_reply_to_message called for chat=%s, target=%r",
+        chat_name,
+        target_text,
+    )
+    try:
+        current_chat = get_current_chat_name()
+        same_chat = current_chat == chat_name if current_chat is not None else False
+        if not same_chat:
+            open_result = open_chat_for_contact(chat_name)
+            if isinstance(open_result, dict) and open_result.get("error"):
+                return {
+                    "error": open_result.get("error"),
+                    "chat_name": chat_name,
+                    "candidates": open_result.get("candidates", {}),
+                    "sent": False,
+                }
+
+        result = quote_and_reply(
+            target_text=target_text,
+            reply_text=reply_message,
+        )
+        result["chat_name"] = chat_name
+        return result
+    except Exception as exc:
+        logger.exception(
+            "Error in quote_reply_to_message for chat=%s: %s",
+            chat_name,
+            exc,
+        )
+        return {
+            "error": str(exc),
+            "chat_name": chat_name,
+        }
+
+
 def main() -> None:
     """
     Entry point for the WeChat MCP server.
@@ -284,3 +340,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/src/wechat_mcp/quote_reply_utils.py
+++ b/src/wechat_mcp/quote_reply_utils.py
@@ -1,0 +1,186 @@
+"""
+Utilities for quoting and replying to a specific message in WeChat.
+
+This module provides the ability to right-click on a message in the
+currently open chat, select "Quote" from the context menu, and then
+type and send a reply with the quoted message attached.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from ApplicationServices import (
+    AXUIElementCopyAttributeValue,
+    kAXChildrenAttribute,
+    kAXRoleAttribute,
+    kAXTitleAttribute,
+    kAXValueAttribute,
+)
+from Quartz import (
+    CGEventCreateMouseEvent,
+    CGEventPost,
+    CGPoint,
+    kCGEventRightMouseDown,
+    kCGEventRightMouseUp,
+    kCGHIDEventTap,
+)
+
+from .logging_config import logger
+from .wechat_accessibility import (
+    ax_get,
+    axvalue_to_point,
+    axvalue_to_size,
+    click_element_center,
+    dfs,
+    get_wechat_ax_app,
+    kAXPositionAttribute,
+    kAXSizeAttribute,
+)
+from .fetch_messages_by_chat_utils import get_messages_list
+from .reply_to_messages_by_chat_utils import find_input_field, press_return, send_message
+
+
+def right_click_element_center(element) -> None:
+    """
+    Synthesize a right mouse click at the visual center of the given
+    AX element, which opens the context menu in WeChat.
+    """
+    pos_ref = ax_get(element, kAXPositionAttribute)
+    size_ref = ax_get(element, kAXSizeAttribute)
+    point = axvalue_to_point(pos_ref)
+    size = axvalue_to_size(size_ref)
+    if point is None or size is None:
+        raise RuntimeError("Failed to get bounds for element to right-click")
+    x, y = point
+    w, h = size
+    cx = x + w / 2.0
+    cy = y + h / 2.0
+    event_down = CGEventCreateMouseEvent(
+        None, kCGEventRightMouseDown, CGPoint(cx, cy), 0
+    )
+    event_up = CGEventCreateMouseEvent(
+        None, kCGEventRightMouseUp, CGPoint(cx, cy), 0
+    )
+    CGEventPost(kCGHIDEventTap, event_down)
+    time.sleep(0.05)
+    CGEventPost(kCGHIDEventTap, event_up)
+
+
+def find_context_menu_item(ax_app, item_title: str, timeout: float = 3.0):
+    """
+    Wait for a context menu to appear and find a menu item by title.
+
+    WeChat's context menu items (Copy, Quote, Forward, etc.) are
+    standard AX menu items that can be located via DFS.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        def is_menu_item(el, role, title, identifier):
+            return (
+                role == "AXMenuItem"
+                and title is not None
+                and item_title.lower() in str(title).lower()
+            )
+
+        found = dfs(ax_app, is_menu_item)
+        if found is not None:
+            return found
+        time.sleep(0.1)
+    return None
+
+
+def find_message_element(msg_list, target_text: str):
+    """
+    Find a message element in the message list whose text content
+    contains the target text.
+
+    Returns the AX element for the matching message, or None.
+    """
+    children = ax_get(msg_list, kAXChildrenAttribute) or []
+    best_match = None
+    best_len = float("inf")
+    for child in children:
+        text = ax_get(child, kAXValueAttribute) or ax_get(child, kAXTitleAttribute)
+        if text and target_text in str(text):
+            # Prefer the shortest match to avoid matching overly broad elements
+            if len(str(text)) < best_len:
+                best_match = child
+                best_len = len(str(text))
+    return best_match
+
+
+def dismiss_context_menu(ax_app) -> None:
+    """
+    Press Escape to dismiss any open context menu.
+    """
+    from Quartz import CGEventCreateKeyboardEvent, CGEventSetFlags
+
+    keycode_escape = 53
+    event_down = CGEventCreateKeyboardEvent(None, keycode_escape, True)
+    CGEventSetFlags(event_down, 0)
+    event_up = CGEventCreateKeyboardEvent(None, keycode_escape, False)
+    CGEventSetFlags(event_up, 0)
+    CGEventPost(kCGHIDEventTap, event_down)
+    CGEventPost(kCGHIDEventTap, event_up)
+
+
+def quote_and_reply(target_text: str, reply_text: str) -> dict[str, Any]:
+    """
+    Quote a specific message and send a reply.
+
+    Steps:
+    1. Find the message element containing `target_text` in the
+       currently open chat's message list.
+    2. Right-click on that message to open the context menu.
+    3. Click the "Quote" menu item.
+    4. Type the reply text into the input field and send.
+
+    Args:
+        target_text: A substring of the message to quote. Must be
+            unique enough to identify the correct message.
+        reply_text: The reply text to send along with the quote.
+
+    Returns:
+        A dict with keys ``quoted_text``, ``reply_text``, and ``sent``.
+    """
+    ax_app = get_wechat_ax_app()
+    msg_list = get_messages_list(ax_app)
+
+    # Step 1: Find the target message
+    msg_element = find_message_element(msg_list, target_text)
+    if msg_element is None:
+        raise RuntimeError(
+            f"Could not find a message containing: {target_text!r}"
+        )
+    logger.info("Found message element for quote target: %r", target_text)
+
+    # Step 2: Right-click to open context menu
+    right_click_element_center(msg_element)
+    time.sleep(0.5)
+
+    # Step 3: Find and click "Quote" in the context menu
+    quote_item = find_context_menu_item(ax_app, "Quote")
+    if quote_item is None:
+        # Try Chinese label as fallback
+        quote_item = find_context_menu_item(ax_app, "引用")
+    if quote_item is None:
+        dismiss_context_menu(ax_app)
+        raise RuntimeError(
+            "Could not find 'Quote' item in the context menu"
+        )
+    click_element_center(quote_item)
+    logger.info("Clicked 'Quote' in context menu")
+    time.sleep(0.3)
+
+    # Step 4: Type reply and send
+    send_message(reply_text)
+    logger.info("Quote-reply sent: quoted=%r, reply=%r", target_text, reply_text)
+
+    return {
+        "quoted_text": target_text,
+        "reply_text": reply_text,
+        "sent": True,
+    }
+

--- a/tests/test_quote_reply.py
+++ b/tests/test_quote_reply.py
@@ -1,0 +1,62 @@
+"""
+Smoke tests for the quote_reply_utils module.
+
+These tests verify the module structure and imports without requiring
+a running WeChat instance or macOS Accessibility API.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import MagicMock
+
+
+def _mock_macos_modules():
+    """Mock macOS-specific modules so tests can run on any platform."""
+    mock_modules = [
+        "AppKit",
+        "ApplicationServices",
+        "Quartz",
+        "PIL",
+        "PIL.ImageGrab",
+    ]
+    mocks = {}
+    for mod_name in mock_modules:
+        if mod_name not in sys.modules:
+            mocks[mod_name] = MagicMock()
+            sys.modules[mod_name] = mocks[mod_name]
+    return mocks
+
+
+def test_module_imports():
+    """Verify that quote_reply_utils can be imported."""
+    _mock_macos_modules()
+    try:
+        from wechat_mcp import quote_reply_utils  # noqa: F401
+
+        assert hasattr(quote_reply_utils, "quote_and_reply")
+        assert hasattr(quote_reply_utils, "right_click_element_center")
+        assert hasattr(quote_reply_utils, "find_context_menu_item")
+        assert hasattr(quote_reply_utils, "find_message_element")
+        print("PASS: quote_reply_utils imports successfully")
+    except Exception as exc:
+        print(f"SKIP: Cannot import on this platform: {exc}")
+
+
+def test_mcp_server_has_tool():
+    """Verify that mcp_server registers the quote_reply_to_message tool."""
+    _mock_macos_modules()
+    try:
+        from wechat_mcp import mcp_server  # noqa: F401
+
+        assert hasattr(mcp_server, "quote_reply_to_message")
+        print("PASS: mcp_server has quote_reply_to_message tool")
+    except Exception as exc:
+        print(f"SKIP: Cannot import on this platform: {exc}")
+
+
+if __name__ == "__main__":
+    test_module_imports()
+    test_mcp_server_has_tool()
+


### PR DESCRIPTION
## Summary

Add a new MCP tool `quote_reply_to_message` that enables quoting a specific message and sending a reply with the quoted context attached. This allows LLMs to have more natural conversations by referencing specific messages.

## New Tool: `quote_reply_to_message`

**Parameters:**
- `chat_name` (str): The name of the contact or group chat
- `target_text` (str): A unique substring of the message to quote
- `reply_message` (str): The reply text to send

**How it works:**
1. Opens the specified chat (or stays if already open)
2. Finds the message element containing `target_text` in the visible message list
3. Right-clicks the message to open the native macOS context menu
4. Clicks "Quote" (supports both English and Chinese WeChat UI: "Quote" / "引用")
5. Types the reply and sends it with the quoted message attached

**Returns:**
```json
{
  "chat_name": "Contact or Group",
  "quoted_text": "The text that was quoted",
  "reply_text": "The reply that was sent",
  "sent": true
}
```

## Files Changed

- **`src/wechat_mcp/quote_reply_utils.py`** (new): Core implementation with right-click context menu interaction
- **`src/wechat_mcp/mcp_server.py`**: Register the new tool with `@mcp.tool()` decorator
- **`tests/test_quote_reply.py`** (new): Smoke tests for the new module
- **`README.md`**, **`docs/README_zh.md`**: Add feature description (EN + CN)
- **`docs/detailed-guide.md`**: Add API documentation and module reference

## Testing

Tested end-to-end on macOS with WeChat for Mac:
- Successfully quotes messages in both 1:1 chats and group chats
- Handles both English ("Quote") and Chinese ("引用") context menu labels
- Properly dismisses context menu on failure via Escape key…cific messages