### PR TITLE
bot-wechat

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,3 +167,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 ## License
 
 MIT License - see [LICENSE](LICENSE) file for details
+
+
+
+wechat-mcp --transport stdio

--- a/src/wechat_mcp/fetch_messages_by_chat_utils.py
+++ b/src/wechat_mcp/fetch_messages_by_chat_utils.py
@@ -136,6 +136,28 @@ def count_colored_pixels(
 SenderLabel = Literal["ME", "OTHER", "UNKNOWN"]
 
 
+def classify_sender_by_position(
+    list_origin, list_size, message_pos, message_size
+) -> SenderLabel:
+    """
+    Classify sender purely from AX coordinates: messages from ME are
+    right-aligned, messages from OTHER are left-aligned.
+    """
+    list_x, _ = list_origin
+    list_w, _ = list_size
+    msg_x, _ = message_pos
+    msg_w, _ = message_size
+
+    list_center_x = list_x + list_w / 2.0
+    msg_center_x = msg_x + msg_w / 2.0
+
+    if msg_center_x > list_center_x * 1.05:
+        return "ME"
+    if msg_center_x < list_center_x * 0.95:
+        return "OTHER"
+    return "UNKNOWN"
+
+
 def classify_sender_for_message(
     image, list_origin, message_pos, message_size
 ) -> SenderLabel:
@@ -219,9 +241,12 @@ def fetch_recent_messages(
     scrolls = 0
     no_new_counter = 0
 
-    while True:
-        image, list_origin, _ = capture_message_area(msg_list)
+    list_pos_ref = ax_get(msg_list, kAXPositionAttribute)
+    list_size_ref = ax_get(msg_list, kAXSizeAttribute)
+    list_origin = axvalue_to_point(list_pos_ref)
+    list_size = axvalue_to_size(list_size_ref)
 
+    while True:
         children = ax_get(msg_list, kAXChildrenAttribute) or []
         visible: list[ChatMessage] = []
 
@@ -234,10 +259,10 @@ def fetch_recent_messages(
             size_ref = ax_get(child, kAXSizeAttribute)
             point = axvalue_to_point(pos_ref)
             size = axvalue_to_size(size_ref)
-            if point is None or size is None:
+            if point is None or size is None or list_origin is None or list_size is None:
                 sender: SenderLabel = "UNKNOWN"
             else:
-                sender = classify_sender_for_message(image, list_origin, point, size)
+                sender = classify_sender_by_position(list_origin, list_size, point, size)
 
             visible.append(ChatMessage(sender=sender, text=str(text)))
 

--- a/src/wechat_mcp/mcp_server.py
+++ b/src/wechat_mcp/mcp_server.py
@@ -13,7 +13,7 @@ from .add_contact_by_wechat_id_utils import (
 from .fetch_messages_by_chat_utils import ChatMessage, fetch_recent_messages
 from .publish_moment_utils import publish_moment_without_media as ax_publish_moment
 from .reply_to_messages_by_chat_utils import send_message
-from .wechat_accessibility import get_current_chat_name, open_chat_for_contact
+from .wechat_accessibility import get_current_chat_name, hide_wechat, open_chat_for_contact
 
 
 mcp = FastMCP("WeChat Helper MCP Server")
@@ -57,6 +57,7 @@ def fetch_messages_by_chat(
                 return [enriched]
 
         messages: list[ChatMessage] = fetch_recent_messages(last_n=last_n)
+        hide_wechat()
         result = [msg.to_dict() for msg in messages]
         logger.info("Returning %d messages for chat=%s", len(result), chat_name)
         return result
@@ -122,6 +123,7 @@ def reply_to_messages_by_chat(
                 }
                 return enriched
 
+        hide_wechat()
         sent = False
         if reply_message is not None and reply_message.strip():
             send_message(reply_message)

--- a/src/wechat_mcp/reply_to_messages_by_chat_utils.py
+++ b/src/wechat_mcp/reply_to_messages_by_chat_utils.py
@@ -12,26 +12,25 @@ from ApplicationServices import (
 )
 from Quartz import (
     CGEventCreateKeyboardEvent,
-    CGEventPost,
+    CGEventPostToPid,
     CGEventSetFlags,
-    kCGHIDEventTap,
 )
 
 from .logging_config import logger
-from .wechat_accessibility import dfs, get_wechat_ax_app
+from .wechat_accessibility import dfs, get_wechat_ax_app, get_wechat_pid
 
 
-def press_return() -> None:
+def press_return(pid: int) -> None:
     """
-    Synthesize a Return key press.
+    Synthesize a Return key press directed at the given process PID.
     """
     keycode_return = 36
     event_down = CGEventCreateKeyboardEvent(None, keycode_return, True)
     CGEventSetFlags(event_down, 0)
     event_up = CGEventCreateKeyboardEvent(None, keycode_return, False)
     CGEventSetFlags(event_up, 0)
-    CGEventPost(kCGHIDEventTap, event_down)
-    CGEventPost(kCGHIDEventTap, event_up)
+    CGEventPostToPid(pid, event_down)
+    CGEventPostToPid(pid, event_up)
 
 
 def find_input_field(ax_app: Any):
@@ -66,5 +65,6 @@ def send_message(text: str) -> None:
         raise RuntimeError(f"Failed to set input text, AX error {err}")
 
     time.sleep(0.1)
-    press_return()
+    pid = get_wechat_pid()
+    press_return(pid)
     logger.info("Message sent")

--- a/src/wechat_mcp/wechat_accessibility.py
+++ b/src/wechat_mcp/wechat_accessibility.py
@@ -85,11 +85,32 @@ def get_wechat_ax_app() -> Any:
         raise RuntimeError("WeChat is not running")
 
     app = apps[0]
-    app.activateWithOptions_(AppKit.NSApplicationActivateIgnoringOtherApps)
+    # app.activateWithOptions_(AppKit.NSApplicationActivateIgnoringOtherApps)
     logger.info(
         "Activated WeChat (bundle_id=%s, pid=%s)", bundle_id, app.processIdentifier()
     )
     return AXUIElementCreateApplication(app.processIdentifier())
+
+
+def get_wechat_pid() -> int:
+    """Return the PID of the running WeChat process."""
+    bundle_id = "com.tencent.xinWeChat"
+    apps = AppKit.NSRunningApplication.runningApplicationsWithBundleIdentifier_(
+        bundle_id
+    )
+    if not apps:
+        raise RuntimeError("WeChat is not running")
+    return apps[0].processIdentifier()
+
+
+def hide_wechat() -> None:
+    """Hide the WeChat application window."""
+    bundle_id = "com.tencent.xinWeChat"
+    apps = AppKit.NSRunningApplication.runningApplicationsWithBundleIdentifier_(
+        bundle_id
+    )
+    if apps:
+        apps[0].hide()
 
 
 def _find_window_by_title(ax_app: Any, title: str):
@@ -332,6 +353,14 @@ def open_chat_for_contact(chat_name: str) -> dict[str, Any] | None:
     Callers can use this to ask the LLM to choose a more specific target.
     """
     logger.info("Opening chat for name: %s", chat_name)
+    # The AX tree is not fully exposed when WeChat is in the background.
+    # Temporarily activate WeChat for navigation, then hide it after the chat
+    # is open. Text input and send work fine in the background.
+    bundle_id = "com.tencent.xinWeChat"
+    wechat_app = AppKit.NSRunningApplication.runningApplicationsWithBundleIdentifier_(bundle_id)[0]
+    wechat_app.activateWithOptions_(AppKit.NSApplicationActivateIgnoringOtherApps)
+    time.sleep(0.2)
+
     ax_app = get_wechat_ax_app()
 
     element = find_chat_element_by_name(ax_app, chat_name)

--- a/wechat_reply.py
+++ b/wechat_reply.py
@@ -1,0 +1,84 @@
+import asyncio
+import json
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+async def run_automation():
+    server_params = StdioServerParameters(
+        command="wechat-mcp",
+        args=["--transport", "stdio"]
+    )
+
+    chat_name = "Yu Song"
+    polling_interval = 10  # seconds
+
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            # Establish baseline
+            print(f"Fetching initial history for: {chat_name}")
+            initial = await session.call_tool("fetch_messages_by_chat", {
+                "chat_name": chat_name,
+                "last_n": 50
+            })
+
+            def parse_messages(result):
+                items = result.content if hasattr(result, "content") else []
+                messages = []
+                for item in items:
+                    raw = item.text if hasattr(item, "text") else str(item)
+                    try:
+                        parsed = json.loads(raw)
+                        if isinstance(parsed, list):
+                            messages.extend(parsed)
+                        elif isinstance(parsed, dict):
+                            messages.append(parsed)
+                    except (json.JSONDecodeError, TypeError):
+                        pass
+                return messages
+
+            messages = parse_messages(initial)
+            last_msg = messages[-1] if messages else None
+            print(f"Baseline: {last_msg}")
+
+            # Polling loop
+            print(f"Polling every {polling_interval}s...")
+            while True:
+                try:
+                    await asyncio.sleep(polling_interval)
+
+                    update = await session.call_tool("fetch_messages_by_chat", {
+                        "chat_name": chat_name,
+                        "last_n": 1
+                    })
+
+                    current = parse_messages(update)
+                    if not current:
+                        continue
+
+                    latest = current[-1]
+                    #print("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@", latest, last_msg)
+
+                    if latest != last_msg and latest.get("sender") != "ME" and latest['text'] != last_msg['text']:
+                        print(f"New message: {latest.get('text')}")
+
+                        reply_text = "Received! Thanks for letting me know."
+                        await session.call_tool("reply_to_messages_by_chat", {
+                            "chat_name": chat_name,
+                            "reply_message": reply_text
+                        })
+                        print(f"Replied: {reply_text}")
+
+                    last_msg = latest
+
+                except Exception as e:
+                    print(f"Error during poll: {e}")
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(run_automation())
+    except KeyboardInterrupt:
+        print("\nBot stopped.")


### PR DESCRIPTION
## Summary
- Add a polling bot (`wechat_reply.py`) that monitors a WeChat chat every 10s and auto-replies when a new message from another person arrives
- Fix WeChat being brought to foreground on every tool call — now only activates briefly for AX navigation, then hides immediately after
- Fix sender classification returning `UNKNOWN` in background mode by replacing screenshot pixel analysis with AX coordinate positional heuristic

## Changes

### Background mode fixes
- Comment out `activateWithOptions_` in `get_wechat_ax_app()` so WeChat no longer steals focus on every call
- Move `hide_wechat()` to `mcp_server.py` so it's called *after* `fetch_recent_messages` (while WeChat is still visible for accurate AX positions) and *before* `send_message` (which works in background)
- Only re-activate WeChat temporarily inside `open_chat_for_contact` when AX navigation is needed

### Sender detection fix
- Replace screenshot-based `classify_sender_for_message` with `classify_sender_by_position` — uses AX element coordinates to determine left (OTHER) vs right (ME) bubble alignment, works reliably when WeChat is hidden

### Return key fix
- Switch `press_return` from `CGEventPost(kCGHIDEventTap)` to `CGEventPostToPid(pid)` so the Enter key is sent directly to WeChat's process regardless of which app is in the foreground

## Files Changed
- `wechat_reply.py` — new polling bot script
- `src/wechat_mcp/wechat_accessibility.py` — background mode navigation, `hide_wechat()` helper, `get_wechat_pid()`
- `src/wechat_mcp/fetch_messages_by_chat_utils.py` — positional sender classifier
- `src/wechat_mcp/reply_to_messages_by_chat_utils.py` — `CGEventPostToPid` for Return key
- `src/wechat_mcp/mcp_server.py` — `hide_wechat()` call placement