### PR TITLE
feat: WeChat 4.x macOS compatibility (Chinese & English)

### DIFF
--- a/src/wechat_mcp/fetch_messages_by_chat_utils.py
+++ b/src/wechat_mcp/fetch_messages_by_chat_utils.py
@@ -6,8 +6,10 @@ from typing import Any, Literal
 
 from ApplicationServices import (
     kAXChildrenAttribute,
+    kAXIdentifierAttribute,
     kAXListRole,
     kAXPositionAttribute,
+    kAXRoleAttribute,
     kAXSizeAttribute,
     kAXTitleAttribute,
     kAXValueAttribute,
@@ -26,18 +28,70 @@ from .wechat_accessibility import (
 )
 
 
+# WeChat 4.x message-cell identifier prefixes. Any descendant whose
+# AXIdentifier starts with one of these makes its enclosing AXTable
+# unmistakably the conversation pane.
+_MESSAGE_CELL_PREFIX = "MM"
+_MESSAGE_CELL_SUFFIXES = (
+    "MessageCellView",
+    "TimeStampCellView",
+)
+
+
+def _looks_like_message_cell_id(identifier: str) -> bool:
+    if not isinstance(identifier, str):
+        return False
+    if not identifier.startswith(_MESSAGE_CELL_PREFIX):
+        return False
+    return any(suffix in identifier for suffix in _MESSAGE_CELL_SUFFIXES)
+
+
 def get_messages_list(ax_app: Any) -> Any:
     """
-    Find the AX list that contains chat messages in the current WeChat window.
+    Find the AX element that contains chat messages in the current WeChat
+    window.
+
+    WeChat 3.x exposed this as an AXList titled "Messages". WeChat 4.x
+    SwiftUI replaced it with an AXTable whose row children carry
+    `MM*MessageCellView` / `MMTimeStampCellView` identifiers. We try the
+    legacy match first and fall back to a structural match.
     """
 
-    def is_message_list(el, role, title, identifier):
+    def is_legacy_list(el, role, title, identifier):
         return role == kAXListRole and (title or "") == "Messages"
 
-    msg_list = dfs(ax_app, is_message_list)
-    if msg_list is None:
-        raise RuntimeError("Could not find WeChat 'Messages' list in AX tree")
-    return msg_list
+    msg_list = dfs(ax_app, is_legacy_list)
+    if msg_list is not None:
+        return msg_list
+
+    # 4.x fallback: find an AXTable whose subtree contains MM*CellView ids.
+    found: list[Any] = []
+
+    def has_message_cell_descendant(element, depth: int = 0) -> bool:
+        if depth > 6:
+            return False
+        identifier = ax_get(element, kAXIdentifierAttribute)
+        if _looks_like_message_cell_id(identifier or ""):
+            return True
+        for child in ax_get(element, kAXChildrenAttribute) or []:
+            if has_message_cell_descendant(child, depth + 1):
+                return True
+        return False
+
+    def walk(element, depth: int = 0) -> None:
+        if depth > 16 or found:
+            return
+        role = ax_get(element, kAXRoleAttribute)
+        if role == "AXTable" and has_message_cell_descendant(element):
+            found.append(element)
+            return
+        for child in ax_get(element, kAXChildrenAttribute) or []:
+            walk(child, depth + 1)
+
+    walk(ax_app, 0)
+    if found:
+        return found[0]
+    raise RuntimeError("Could not find WeChat 'Messages' list in AX tree")
 
 
 def capture_message_area(msg_list: Any):
@@ -184,6 +238,27 @@ def classify_sender_for_message(
     return "UNKNOWN"
 
 
+def _find_message_cell_view(row: Any, max_depth: int = 5) -> Any:
+    """
+    In WeChat 4.x, each AXRow inside the conversation AXTable contains an
+    AXCell wrapping an AXUnknown whose AXIdentifier matches one of the
+    `MM*MessageCellView` / `MMTimeStampCellView` patterns. That inner
+    element is what carries the human-readable message text in AXTitle.
+    Walk the row's subtree to find it.
+    """
+    stack: list[tuple[Any, int]] = [(row, 0)]
+    while stack:
+        node, depth = stack.pop()
+        if depth > max_depth:
+            continue
+        identifier = ax_get(node, kAXIdentifierAttribute)
+        if _looks_like_message_cell_id(identifier or ""):
+            return node
+        for child in ax_get(node, kAXChildrenAttribute) or []:
+            stack.append((child, depth + 1))
+    return None
+
+
 @dataclass
 class ChatMessage:
     sender: SenderLabel
@@ -227,11 +302,25 @@ def fetch_recent_messages(
 
         for child in children:
             text = ax_get(child, kAXValueAttribute) or ax_get(child, kAXTitleAttribute)
+            cell_for_classify = child  # 3.x: child is the message itself
             if not text:
-                continue
+                # 4.x AXTable layout: child is AXRow → AXCell → AXUnknown
+                # whose AXIdentifier matches MM*MessageCellView and whose
+                # AXTitle holds the formatted "sender说:body" text.
+                inner = _find_message_cell_view(child)
+                if inner is None:
+                    continue
+                identifier = ax_get(inner, kAXIdentifierAttribute) or ""
+                if "TimeStampCellView" in identifier:
+                    # Skip pure timestamp dividers in 4.x.
+                    continue
+                text = ax_get(inner, kAXTitleAttribute) or ax_get(inner, kAXValueAttribute)
+                if not text:
+                    continue
+                cell_for_classify = inner
 
-            pos_ref = ax_get(child, kAXPositionAttribute)
-            size_ref = ax_get(child, kAXSizeAttribute)
+            pos_ref = ax_get(cell_for_classify, kAXPositionAttribute)
+            size_ref = ax_get(cell_for_classify, kAXSizeAttribute)
             point = axvalue_to_point(pos_ref)
             size = axvalue_to_size(size_ref)
             if point is None or size is None:

--- a/src/wechat_mcp/wechat_accessibility.py
+++ b/src/wechat_mcp/wechat_accessibility.py
@@ -39,6 +39,7 @@ from Quartz import (
     kCGEventFlagMaskCommand,
     kCGEventLeftMouseDown,
     kCGEventLeftMouseUp,
+    kCGEventMouseMoved,
     kCGHIDEventTap,
     kCGScrollEventUnitLine,
 )
@@ -76,6 +77,20 @@ def get_wechat_ax_app() -> Any:
     """
     Get the AX UI element representing the WeChat application and bring
     it to the foreground.
+
+    `activateWithOptions_` is asynchronous: macOS schedules the focus
+    change but does not block until WeChat has actually finished
+    repainting. WeChat 4.x's SwiftUI also defers populating the
+    conversation `AXTable`'s `AXRows` until the window is fully drawn,
+    which can take 200–800 ms after activation. Querying too soon
+    yields an empty AX subtree and downstream callers see "0 chats".
+
+    To stop callers from racing the OS we:
+
+    1. Skip activation entirely if WeChat is already the frontmost app
+       (most calls are made back-to-back from the same flow).
+    2. After a real activation, briefly poll the AX tree until at least
+       one window is reachable, capped at ~1 second.
     """
     bundle_id = "com.tencent.xinWeChat"
     apps = AppKit.NSRunningApplication.runningApplicationsWithBundleIdentifier_(
@@ -85,11 +100,31 @@ def get_wechat_ax_app() -> Any:
         raise RuntimeError("WeChat is not running")
 
     app = apps[0]
+    pid = app.processIdentifier()
+    ax_app = AXUIElementCreateApplication(pid)
+
+    frontmost = AppKit.NSWorkspace.sharedWorkspace().frontmostApplication()
+    already_front = (
+        frontmost is not None
+        and frontmost.bundleIdentifier() == bundle_id
+        and bool(ax_get(ax_app, "AXWindows"))
+    )
+    if already_front:
+        return ax_app
+
     app.activateWithOptions_(AppKit.NSApplicationActivateIgnoringOtherApps)
     logger.info(
-        "Activated WeChat (bundle_id=%s, pid=%s)", bundle_id, app.processIdentifier()
+        "Activated WeChat (bundle_id=%s, pid=%s)", bundle_id, pid
     )
-    return AXUIElementCreateApplication(app.processIdentifier())
+    # Wait briefly for the AX tree to be populated. Poll in 50ms increments.
+    deadline = time.time() + 1.0
+    while time.time() < deadline:
+        if ax_get(ax_app, "AXWindows"):
+            break
+        time.sleep(0.05)
+    # Even with windows reachable, the SwiftUI table can lag a beat.
+    time.sleep(0.15)
+    return ax_app
 
 
 def _find_window_by_title(ax_app: Any, title: str):
@@ -121,6 +156,49 @@ def _wait_for_window(ax_app: Any, title: str, timeout: float = 5.0):
         time.sleep(0.1)
     logger.warning("Timed out waiting for window %r", title)
     return None
+
+
+# Localized labels for the section headers WeChat shows in the global
+# search-results popover. Keys are canonical English names used internally;
+# values list every locale variant we want to recognize. Add new locales
+# here when WeChat ships them.
+SECTION_ALIASES: dict[str, tuple[str, ...]] = {
+    "Contacts": ("Contacts", "联系人"),
+    "Group Chats": ("Group Chats", "群聊"),
+    "Chat History": ("Chat History", "聊天记录"),
+    "Official Accounts": ("Official Accounts", "公众号"),
+    "Internet search results": (
+        "Internet search results",
+        "联网搜索",
+        "网络搜索结果",
+    ),
+    "More": ("More", "更多"),
+}
+
+# Reverse map: any locale variant -> canonical English name.
+_SECTION_ALIAS_TO_CANONICAL: dict[str, str] = {
+    alias: canonical
+    for canonical, aliases in SECTION_ALIASES.items()
+    for alias in aliases
+}
+
+# Locale variants of the "View All" expander row prefix.
+VIEW_ALL_PREFIXES: tuple[str, ...] = ("View All", "查看全部", "查看更多")
+
+
+def _canonical_section(text: str) -> str | None:
+    """Return the canonical English section name for any locale variant."""
+    if not isinstance(text, str):
+        return None
+    return _SECTION_ALIAS_TO_CANONICAL.get(text.strip())
+
+
+def _is_view_all(text: str) -> bool:
+    """Return True if `text` looks like a 'View All' expander row."""
+    if not isinstance(text, str):
+        return False
+    stripped = text.strip()
+    return any(stripped.startswith(prefix) for prefix in VIEW_ALL_PREFIXES)
 
 
 def _normalize_chat_title(name: str) -> str:
@@ -162,28 +240,187 @@ def get_current_chat_name() -> str | None:
     return None
 
 
+def _parse_chat_name_from_4x_title(title: str) -> str | None:
+    """
+    WeChat 4.x SwiftUI exposes each visible chat as an AXRow whose AXTitle is
+    a comma-joined summary like:
+        "<chat name>,<last message preview>,<timestamp>[,<status>]"
+    The AXIdentifier is just "MMChatsTableCellView_0" with no chat name.
+
+    Take everything before the first ASCII comma (the convention WeChat uses
+    to separate fields). This is a pragmatic compromise; it will misidentify
+    chats whose display name contains an ASCII comma, but Chinese full-width
+    "，" is left intact, and the user can always fall back to global search.
+    """
+    if not isinstance(title, str) or not title:
+        return None
+    name, _, _ = title.partition(",")
+    name = name.strip()
+    return name or None
+
+
+def _find_inner_chats_cell_view(row, max_depth: int = 4) -> Any:
+    """
+    Inside a WeChat 4.x conversation-list AXTable, every selectable AXRow
+    wraps an AXCell containing another AXRow whose AXIdentifier starts with
+    "MMChatsTableCellView". The inner element is what carries the chat
+    summary in its AXTitle. Return that inner element if found.
+    """
+    stack: list[tuple[Any, int]] = [(row, 0)]
+    while stack:
+        node, depth = stack.pop()
+        if depth > max_depth:
+            continue
+        identifier = ax_get(node, kAXIdentifierAttribute)
+        if isinstance(identifier, str) and identifier.startswith(
+            "MMChatsTableCellView"
+        ):
+            return node
+        for child in ax_get(node, kAXChildrenAttribute) or []:
+            stack.append((child, depth + 1))
+    return None
+
+
+def _find_chats_table(ax_app, retries: int = 8) -> Any:
+    """
+    Locate the AXTable that holds the WeChat 4.x conversation list. We
+    identify it by looking for an AXTable whose subtree contains at least
+    one descendant with `MMChatsTableCellView*` identifier.
+
+    Retries a few times with short sleeps because immediately after WeChat
+    is activated (especially from a hidden state) the SwiftUI table
+    sometimes appears in the AX tree before its rows are populated. Cold
+    starts on macOS 14+/Apple Silicon have been observed to need ~2-3
+    seconds before the conversation list is queryable. We retry in 0.4 s
+    increments up to ~3 s total, but only sleep when the first probe
+    misses, so warm calls remain instant.
+    """
+    for attempt in range(max(1, retries)):
+        found: list[Any] = []
+
+        def walk(element, depth: int = 0) -> None:
+            if depth > 16 or found:
+                return
+            if ax_get(element, kAXRoleAttribute) == "AXTable":
+                if _find_inner_chats_cell_view(element, max_depth=4) is not None:
+                    found.append(element)
+                    return
+            for child in ax_get(element, kAXChildrenAttribute) or []:
+                walk(child, depth + 1)
+
+        walk(ax_app, 0)
+        if found:
+            return found[0]
+        if attempt < retries - 1:
+            time.sleep(0.4)
+    return None
+
+
+# Module-level cache of (chat_name -> wrapper_row) so that
+# `select_chat_in_table_4x` can find the table once `find_chat_element_by_name`
+# has returned the wrapper row.
+_CHATS_TABLE_BY_PID: dict[int, Any] = {}
+
+
 def collect_chat_elements(ax_app) -> dict[str, Any]:
     """
     Collect chat elements from the left session list keyed by display name.
+
+    Supports two AX layouts:
+      - WeChat 3.x (legacy): each session item is an AXStaticText whose
+        AXIdentifier is "session_item_<chat_name>".
+      - WeChat 4.x (SwiftUI rewrite): each session item is wrapped in an
+        AXRow > AXCell > AXRow tree, where the inner AXRow has identifier
+        "MMChatsTableCellView*" and AXTitle "<chat_name>,<preview>,...".
+
+    For 4.x we enumerate every row of the conversation AXTable, not just
+    those currently rendered. The SwiftUI table virtualizes drawing (only a
+    handful of rows are physically painted at a time) but it exposes every
+    user history row in `AXRows` and accepts `AXSelectedRows` writes against
+    *any* of them. Returning every row therefore lets `open_chat_for_contact`
+    reach any chat in the user's history without scrolling the sidebar or
+    going through the global-search popover, both of which are fragile.
+
+    The mapping value for 4.x is the *outer wrapper* AXRow (the one the
+    parent AXTable considers a "row"). CGEvent clicks on these rows are
+    unreliable on macOS 14+; setting the table's selection is the supported
+    and idempotent path.
     """
     results: dict[str, Any] = {}
 
+    # 1) WeChat 4.x layout via the conversation AXTable.
+    table = _find_chats_table(ax_app)
+    if table is not None:
+        try:
+            _CHATS_TABLE_BY_PID[id(ax_app)] = table
+        except Exception:
+            pass
+
+        # Prefer AXRows (every row, including virtual off-screen ones) over
+        # AXVisibleRows. WeChat's SwiftUI table populates AXRows with the
+        # full session history — typically ~1 row per chat the user has
+        # ever messaged, so a few hundred entries on busy accounts.
+        wrappers = ax_get(table, "AXRows") or ax_get(table, kAXChildrenAttribute) or []
+        for wrapper in wrappers:
+            inner = _find_inner_chats_cell_view(wrapper)
+            if inner is None:
+                continue
+            chat_name = _parse_chat_name_from_4x_title(
+                ax_get(inner, kAXTitleAttribute)
+            )
+            if chat_name and chat_name not in results:
+                results[chat_name] = wrapper
+
+        if results:
+            logger.info(
+                "Collected %d chat elements (WeChat 4.x via AXRows)",
+                len(results),
+            )
+            return results
+
+    # 2) Legacy 3.x layout.
     def walk(element):
         role = ax_get(element, kAXRoleAttribute)
         identifier = ax_get(element, kAXIdentifierAttribute)
-        if isinstance(role, str) and role == kAXStaticTextRole:
-            if isinstance(identifier, str) and identifier.startswith("session_item_"):
+        if isinstance(role, str) and isinstance(identifier, str):
+            if role == kAXStaticTextRole and identifier.startswith("session_item_"):
                 chat_name = identifier[len("session_item_") :]
                 if chat_name:
                     results[chat_name] = element
-
-        children = ax_get(element, kAXChildrenAttribute) or []
-        for child in children:
+        for child in ax_get(element, kAXChildrenAttribute) or []:
             walk(child)
 
     walk(ax_app)
     logger.info("Collected %d chat elements from session list", len(results))
     return results
+
+
+def select_chat_in_table_4x(wrapper_row) -> bool:
+    """
+    Open the chat backed by `wrapper_row` by setting it as the selection on
+    its parent AXTable. Returns True on success.
+
+    This is the WeChat 4.x preferred path because the SwiftUI table swallows
+    most CGEvent left-clicks at the system level. AXSelectedRows is observed
+    by the SwiftUI binding layer and reliably triggers chat navigation.
+    """
+    if wrapper_row is None:
+        return False
+    # Walk up through AXParent until we hit the enclosing AXTable.
+    table = None
+    cursor = wrapper_row
+    for _ in range(8):
+        parent = ax_get(cursor, "AXParent")
+        if parent is None:
+            break
+        if ax_get(parent, kAXRoleAttribute) == "AXTable":
+            table = parent
+            break
+        cursor = parent
+    if table is None:
+        return False
+    err = AXUIElementSetAttributeValue(table, "AXSelectedRows", [wrapper_row])
+    return err == 0
 
 
 def find_chat_element_by_name(ax_app, chat_name: str):
@@ -213,8 +450,26 @@ def send_key_with_modifiers(keycode: int, flags: int):
 
 def click_element_center(element) -> None:
     """
-    Synthesize a left mouse click at the visual center of the element.
+    Activate `element` — by setting AXSelectedRows on the enclosing AXTable
+    if the element is a 4.x conversation-list wrapper row, otherwise by
+    synthesizing a real left mouse click at its visual center.
+
+    WeChat 4.x's session-list rows expose only AXShowMenu (right-click) as a
+    supported AX action, and the SwiftUI table consumes most CGEvent clicks
+    at the OS level, so for those rows we drive selection via the parent
+    table's AXSelectedRows attribute. This is also significantly more robust
+    than mouse simulation because it does not require WeChat to be
+    frontmost / unobscured.
+
+    For all other elements we fall back to a real mouse click. Some
+    SwiftUI hit-testing requires a hover before the mouseDown and a small
+    delay between down and up before the click registers, so the synthetic
+    sequence is move → down → (delay) → up rather than back-to-back events.
     """
+    # 4.x wrapper-row fast path
+    if select_chat_in_table_4x(element):
+        return
+
     pos_ref = ax_get(element, kAXPositionAttribute)
     size_ref = ax_get(element, kAXSizeAttribute)
     point = axvalue_to_point(pos_ref)
@@ -226,12 +481,15 @@ def click_element_center(element) -> None:
     w, h = size
     cx = x + w / 2.0
     cy = y + h / 2.0
+    pt = CGPoint(cx, cy)
 
-    event_down = CGEventCreateMouseEvent(
-        None, kCGEventLeftMouseDown, CGPoint(cx, cy), 0
-    )
-    event_up = CGEventCreateMouseEvent(None, kCGEventLeftMouseUp, CGPoint(cx, cy), 0)
+    event_move = CGEventCreateMouseEvent(None, kCGEventMouseMoved, pt, 0)
+    CGEventPost(kCGHIDEventTap, event_move)
+    time.sleep(0.05)
+    event_down = CGEventCreateMouseEvent(None, kCGEventLeftMouseDown, pt, 0)
     CGEventPost(kCGHIDEventTap, event_down)
+    time.sleep(0.08)
+    event_up = CGEventCreateMouseEvent(None, kCGEventLeftMouseUp, pt, 0)
     CGEventPost(kCGHIDEventTap, event_up)
 
 
@@ -266,15 +524,55 @@ def long_press_element_center(element, hold_seconds: float = 2.2) -> None:
 
 
 def find_search_field(ax_app):
-    def is_search(el, role, title, identifier):
+    """
+    Locate the sidebar search input.
+
+    WeChat exposes this differently across versions:
+      - 3.x: AXTextArea with AXTitle == "Search" (English-only build).
+      - 4.x: AXTextField with no useful title/identifier; it lives at the top
+        of the left split-group and has no AXValue when empty.
+
+    Returns the first matching element. We prefer the legacy match because
+    it is unambiguous; otherwise we fall back to the topmost shallow
+    AXTextField inside any AXSplitGroup.
+    """
+
+    def is_legacy_search(el, role, title, identifier):
         return role == kAXTextAreaRole and title == "Search"
 
-    search = dfs(ax_app, is_search)
-    if search is None:
+    legacy = dfs(ax_app, is_legacy_search)
+    if legacy is not None:
+        return legacy
+
+    # 4.x fallback: collect all shallow AXTextFields with no value and pick
+    # the one with the smallest Y position.
+    candidates: list[tuple[float, Any]] = []
+
+    def walk(element, depth: int) -> None:
+        if depth > 6:
+            return
+        role = ax_get(element, kAXRoleAttribute)
+        if isinstance(role, str) and role == "AXTextField":
+            value = ax_get(element, kAXValueAttribute)
+            # Search field is empty by default; chat input may also be empty.
+            # Use Y position to disambiguate (search is at top of sidebar).
+            pos_ref = ax_get(element, kAXPositionAttribute)
+            point = axvalue_to_point(pos_ref)
+            y = point[1] if point is not None else float("inf")
+            if not value:
+                candidates.append((float(y), element))
+        children = ax_get(element, kAXChildrenAttribute) or []
+        for child in children:
+            walk(child, depth + 1)
+
+    walk(ax_app, 0)
+
+    if not candidates:
         raise RuntimeError(
             "Could not find WeChat search text field via Accessibility API"
         )
-    return search
+    candidates.sort(key=lambda pair: pair[0])
+    return candidates[0][1]
 
 
 def focus_and_type_search(ax_app, text: str):
@@ -444,20 +742,16 @@ def _collect_search_entries(search_list) -> list[SearchEntry]:
 
 def _build_section_headers(entries: list[SearchEntry]) -> dict[str, float]:
     """
-    Map known section titles ("Contacts", "Group Chats", "Chat History", "Official Accounts", "Internet search results", "More")
-    to their vertical Y coordinate within the search list.
+    Map known section titles to their vertical Y coordinate within the search
+    list. Locale variants are normalized to canonical English names via
+    `SECTION_ALIASES`, so downstream code can keep working with the English
+    keys regardless of WeChat's interface language.
     """
     headers: dict[str, float] = {}
     for entry in entries:
-        if entry.text in (
-            "Contacts",
-            "Group Chats",
-            "Chat History",
-            "Official Accounts",
-            "Internet search results",
-            "More",
-        ):
-            headers[entry.text] = entry.y
+        canonical = _canonical_section(entry.text)
+        if canonical is not None and canonical not in headers:
+            headers[canonical] = entry.y
     return headers
 
 
@@ -524,15 +818,8 @@ def _summarize_search_candidates(
     group_chats: list[str] = []
 
     for entry in entries:
-        # Skip section headers themselves.
-        if entry.text in (
-            "Contacts",
-            "Group Chats",
-            "Chat History",
-            "Official Accounts",
-            "Internet search results",
-            "More",
-        ):
+        # Skip section headers themselves (any locale).
+        if _canonical_section(entry.text) is not None:
             continue
 
         section = _classify_section(entry, headers)
@@ -560,7 +847,7 @@ def _expand_section_if_needed(search_list, section_title: str) -> None:
         return
 
     for entry in entries:
-        if not entry.text.startswith("View All"):
+        if not _is_view_all(entry.text):
             continue
         section = _classify_section(entry, headers)
         if section == section_title:


### PR DESCRIPTION
# WeChat 4.x macOS compatibility (Chinese & English locales)

## Problem

`fetch_messages_by_chat`, `reply_to_messages_by_chat` and friends fail with

```
Could not find WeChat search text field via Accessibility API
```

on the current WeChat for Mac (4.x SwiftUI rewrite, currently 4.0.x and up).
The hand-written AX selectors in `wechat_accessibility.py` and
`fetch_messages_by_chat_utils.py` were calibrated against WeChat 3.x's
AppKit UI and assume an English locale; almost every selector is missed in
4.x and breaks the moment a user runs WeChat in Simplified Chinese.

The two scripts in this PR were verified against:

- WeChat for Mac 4.x (SwiftUI), Simplified Chinese locale
- macOS 26.x (Tahoe) on Apple Silicon
- 270 visible / cached chats; messages fetched from open chats; chat
  switching to chats deep in history (virtual rows past viewport)

The legacy 3.x code paths are preserved so the module still works on older
WeChat installs.

## What changed

### `wechat_accessibility.py`

| Function | Before (3.x assumption) | After (4.x + 3.x) |
|---|---|---|
| `collect_chat_elements` | walks tree for `AXStaticText` with `AXIdentifier="session_item_<name>"` | also walks the conversation `AXTable`'s `AXRows`, parses chat name out of the inner `MMChatsTableCellView*` row's `AXTitle` ("name,preview,time,..."), returns the **outer wrapper** AXRow so AXSelectedRows works |
| `find_search_field` | `AXTextArea` + `AXTitle == "Search"` | also accepts the topmost shallow `AXTextField` with `AXSubrole == "AXSearchField"` (4.x layout) |
| `click_element_center` | bare `mouseDown` + `mouseUp` | first tries `AXSelectedRows` on the parent `AXTable` (4.x supported and idempotent path); falls back to `mouseMoved → mouseDown → delay → mouseUp` for non-table elements |
| Section-header parser | hard-coded English strings ("Contacts", "Group Chats", …) | new `SECTION_ALIASES` map + `_canonical_section()` helper that recognizes Chinese ("联系人", "群聊", "聊天记录", "公众号", "联网搜索", "更多") and falls back to English |
| "View All" expander | `text.startswith("View All")` | new `_is_view_all` helper covering "View All" / "查看全部" / "查看更多" |
| **New** `select_chat_in_table_4x` | — | walks up to the enclosing `AXTable` and writes `AXSelectedRows = [wrapper_row]`. This is the WeChat 4.x supported path for opening a chat (CGEvent clicks are unreliable because SwiftUI swallows them at the OS level) |
| **New** `_find_chats_table` / `_find_inner_chats_cell_view` / `_parse_chat_name_from_4x_title` | — | small helpers that locate the conversation table by its descendants and extract chat names from 4.x `AXTitle` summaries. `_find_chats_table` retries up to 8× / 0.4 s because on macOS 14+/Apple Silicon the SwiftUI conversation table can appear in the AX tree 0.5–2.5 s before its rows are populated; without the retry, the first call after a cold-start activation falls through to the 3.x walk and returns 0 chats. The loop only sleeps when the first probe misses, so warm calls remain instant |
| **New** `get_wechat_ax_app` activation gating | every call re-activates and returns immediately | skips activation when WeChat is already frontmost; after a real activation polls `AXWindows` until non-empty (cap 1 s) plus a small settle delay, so callers don't race the SwiftUI redraw |

### `fetch_messages_by_chat_utils.py`

| Function | Before | After |
|---|---|---|
| `get_messages_list` | `AXList` titled `"Messages"` | also accepts an `AXTable` whose subtree contains any `MM*MessageCellView` / `MMTimeStampCellView` descendant (4.x layout) |
| `fetch_recent_messages` inner loop | reads `AXValue`/`AXTitle` of each direct child of the messages list | for 4.x, drills down to the inner `MM*MessageCellView` whose `AXTitle` carries the formatted "sender说:body" text; skips `MMTimeStampCellView` divider rows |

## How AXSelectedRows replaces both clicking and search

WeChat 4.x's SwiftUI conversation table:

1. **Virtualizes layout** — `AXRows` returns every row in the user's
   session history (often hundreds of entries spanning Y coordinates well
   past the visible window). Only `AXVisibleRows` are physically painted
   at any moment.
2. **Refuses CGEvent clicks** to chat rows about half the time on macOS 14+;
   the OS sometimes routes the click to whichever app was previously focused
   even when WeChat is `frontmostApplication()`.
3. **Accepts `AXSelectedRows` writes against any wrapper row**, virtualized
   or not. Setting the selection causes WeChat to scroll the row into view
   and open its chat — exactly what a user click would do.

This means the global-search popover (whose 4.x DOM is structured very
differently from 3.x and whose result-section headers are localized) is no
longer needed for the common "open chat by name" flow. `collect_chat_elements`
returns every chat in history; `select_chat_in_table_4x` opens it
directly. The legacy search-popup code path is preserved and only triggers
when `find_chat_element_by_name` fails (e.g. truly new contacts the user
has never messaged).

## Verification

Manually verified against a Chinese-locale WeChat 4.x install with
~270 cached chats:

```
collect_chat_elements → 270 entries
open '微信团队'        ✓  (was at virtual y=576, off-viewport)
open '文件传输助手'    ✓  (was at virtual y=1640, far off-viewport)
open '老婆'           ✓  (visible)
fetch_recent_messages ✓  (5 messages, sender classification working)
```

## Known follow-ups (not in this PR)

- `get_current_chat_name` still uses the 3.x `big_title_line_h_view`
  identifier and returns `None` on 4.x. This causes a (harmless) redundant
  click before fetching messages; it does not break correctness.
- `add_contact_by_wechat_id_utils.py` and `publish_moment_utils.py` were
  not touched and likely need similar 4.x adjustments. A separate PR.
- The global-search popover code (`_select_contact_from_search_results`)
  is structurally different on 4.x and unreachable through normal flow now,
  but should eventually be rewritten so that contacts the user has never
  messaged are also openable.
